### PR TITLE
feat: add `const` to many methods

### DIFF
--- a/src/sip.rs
+++ b/src/sip.rs
@@ -146,13 +146,13 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
 impl SipHasher {
     /// Creates a new `SipHasher` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher {
+    pub const fn new() -> SipHasher {
         SipHasher::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher(SipHasher24::new_with_keys(key0, key1))
     }
 
@@ -168,7 +168,7 @@ impl SipHasher {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.0.hasher.k0, self.0.hasher.k1)
     }
 
@@ -192,13 +192,13 @@ impl SipHasher {
 impl SipHasher13 {
     /// Creates a new `SipHasher13` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher13 {
+    pub const fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher13` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 {
             hasher: Hasher::new_with_keys(key0, key1),
         }
@@ -216,7 +216,7 @@ impl SipHasher13 {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
     }
 
@@ -240,13 +240,13 @@ impl SipHasher13 {
 impl SipHasher24 {
     /// Creates a new `SipHasher24` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher24 {
+    pub const fn new() -> SipHasher24 {
         SipHasher24::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher24` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher24 {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher24 {
         SipHasher24 {
             hasher: Hasher::new_with_keys(key0, key1),
         }
@@ -264,7 +264,7 @@ impl SipHasher24 {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
     }
 
@@ -287,7 +287,7 @@ impl SipHasher24 {
 
 impl<S: Sip> Hasher<S> {
     #[inline]
-    fn new_with_keys(key0: u64, key1: u64) -> Hasher<S> {
+    const fn new_with_keys(key0: u64, key1: u64) -> Hasher<S> {
         let mut state = Hasher {
             k0: key0,
             k1: key1,
@@ -302,18 +302,20 @@ impl<S: Sip> Hasher<S> {
             ntail: 0,
             _marker: PhantomData,
         };
-        state.reset();
+        state = state.reset();
         state
     }
 
     #[inline]
-    fn reset(&mut self) {
+    #[must_use]
+    const fn reset(mut self) -> Self {
         self.length = 0;
         self.state.v0 = self.k0 ^ 0x736f6d6570736575;
         self.state.v1 = self.k1 ^ 0x646f72616e646f6d;
         self.state.v2 = self.k0 ^ 0x6c7967656e657261;
         self.state.v3 = self.k1 ^ 0x7465646279746573;
         self.ntail = 0;
+        self
     }
 
     // A specialized write function for values with size <= 8.

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -167,13 +167,13 @@ pub trait Hasher128 {
 impl SipHasher {
     /// Creates a new `SipHasher` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher {
+    pub const fn new() -> SipHasher {
         SipHasher::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher(SipHasher24::new_with_keys(key0, key1))
     }
 
@@ -189,7 +189,7 @@ impl SipHasher {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.0.hasher.k0, self.0.hasher.k1)
     }
 
@@ -221,13 +221,13 @@ impl Hasher128 for SipHasher {
 impl SipHasher13 {
     /// Creates a new `SipHasher13` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher13 {
+    pub const fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher13` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 {
             hasher: Hasher::new_with_keys(key0, key1),
         }
@@ -245,7 +245,7 @@ impl SipHasher13 {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
     }
 
@@ -277,13 +277,13 @@ impl Hasher128 for SipHasher13 {
 impl SipHasher24 {
     /// Creates a new `SipHasher24` with the two initial keys set to 0.
     #[inline]
-    pub fn new() -> SipHasher24 {
+    pub const fn new() -> SipHasher24 {
         SipHasher24::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher24` that is keyed off the provided keys.
     #[inline]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher24 {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher24 {
         SipHasher24 {
             hasher: Hasher::new_with_keys(key0, key1),
         }
@@ -301,7 +301,7 @@ impl SipHasher24 {
     }
 
     /// Get the keys used by this hasher
-    pub fn keys(&self) -> (u64, u64) {
+    pub const fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
     }
 
@@ -332,7 +332,7 @@ impl Hasher128 for SipHasher24 {
 
 impl<S: Sip> Hasher<S> {
     #[inline]
-    fn new_with_keys(key0: u64, key1: u64) -> Hasher<S> {
+    const fn new_with_keys(key0: u64, key1: u64) -> Hasher<S> {
         let mut state = Hasher {
             k0: key0,
             k1: key1,
@@ -347,18 +347,20 @@ impl<S: Sip> Hasher<S> {
             ntail: 0,
             _marker: PhantomData,
         };
-        state.reset();
+        state = state.reset();
         state
     }
 
     #[inline]
-    fn reset(&mut self) {
+    #[must_use]
+    const fn reset(mut self) -> Self {
         self.length = 0;
         self.state.v0 = self.k0 ^ 0x736f6d6570736575;
         self.state.v1 = self.k1 ^ 0x646f72616e646f83;
         self.state.v2 = self.k0 ^ 0x6c7967656e657261;
         self.state.v3 = self.k1 ^ 0x7465646279746573;
         self.ntail = 0;
+        self
     }
 
     // A specialized write function for values with size <= 8.
@@ -667,7 +669,7 @@ impl Sip for Sip24Rounds {
 
 impl Hash128 {
     /// Convert into a 16-bytes vector
-    pub fn as_bytes(&self) -> [u8; 16] {
+    pub const fn as_bytes(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         let h1 = self.h1.to_le();
         let h2 = self.h2.to_le();
@@ -680,7 +682,7 @@ impl Hash128 {
 
     /// Convert into a `u128`
     #[inline]
-    pub fn as_u128(&self) -> u128 {
+    pub const fn as_u128(&self) -> u128 {
         let h1 = self.h1.to_le();
         let h2 = self.h2.to_le();
         h1 as u128 | ((h2 as u128) << 64)
@@ -688,7 +690,7 @@ impl Hash128 {
 
     /// Convert into `(u64, u64)`
     #[inline]
-    pub fn as_u64(&self) -> (u64, u64) {
+    pub const fn as_u64(&self) -> (u64, u64) {
         let h1 = self.h1.to_le();
         let h2 = self.h2.to_le();
         (h1, h2)


### PR DESCRIPTION
Only includes one minor change to the signature of one private method (`Hasher::reset`). Everything is is just adding `const` to functions which already support it.